### PR TITLE
Improve extravariants

### DIFF
--- a/src/main/java/com/teamwizardry/librarianlib/core/client/ModelHandler.kt
+++ b/src/main/java/com/teamwizardry/librarianlib/core/client/ModelHandler.kt
@@ -189,7 +189,7 @@ object ModelHandler {
 
                 if (shouldGenItemJson(holder)) generateItemJson(holder, variant)
 
-                val model = ModelResourceLocation(ResourceLocation(modName, variant).toString(), "inventory")
+                val model = ModelResourceLocation(if (variant.contains(':')) variant else "$modName:variant", "inventory")
                 if (!extra) {
                     ModelLoader.setCustomModelResourceLocation(item, index, model)
                     addToCachedLocations(getKey(item, index), model)

--- a/src/main/java/com/teamwizardry/librarianlib/core/client/ModelHandler.kt
+++ b/src/main/java/com/teamwizardry/librarianlib/core/client/ModelHandler.kt
@@ -189,7 +189,7 @@ object ModelHandler {
 
                 if (shouldGenItemJson(holder)) generateItemJson(holder, variant)
 
-                val model = ModelResourceLocation(if (variant.contains(':')) variant else "$modName:variant", "inventory")
+                val model = ModelResourceLocation(if (variant.contains(':')) variant else "$modName:$variant", "inventory")
                 if (!extra) {
                     ModelLoader.setCustomModelResourceLocation(item, index, model)
                     addToCachedLocations(getKey(item, index), model)

--- a/src/main/java/com/teamwizardry/librarianlib/features/utilities/JsonGenerationUtils.kt
+++ b/src/main/java/com/teamwizardry/librarianlib/features/utilities/JsonGenerationUtils.kt
@@ -31,7 +31,7 @@ fun getPathPrefix(modid: String) = paths[modid] ?: "src/main/resources/assets"
 
 private val paths = mutableMapOf<String, String>()
 
-operator fun String.unaryPlus() = this.replace('/', File.separatorChar)
+private operator fun String.unaryPlus() = this.replace('/', File.separatorChar)
 
 fun getPathForBaseBlockstate(block: FileDsl<Block>): String = getPathForBaseBlockstate(block.value)
 

--- a/src/main/java/com/teamwizardry/librarianlib/features/utilities/JsonGenerationUtils.kt
+++ b/src/main/java/com/teamwizardry/librarianlib/features/utilities/JsonGenerationUtils.kt
@@ -31,7 +31,7 @@ fun getPathPrefix(modid: String) = paths[modid] ?: "src/main/resources/assets"
 
 private val paths = mutableMapOf<String, String>()
 
-private operator fun String.unaryPlus() = this.replace("/", File.separator)
+operator fun String.unaryPlus() = this.replace('/', File.separatorChar)
 
 fun getPathForBaseBlockstate(block: FileDsl<Block>): String = getPathForBaseBlockstate(block.value)
 
@@ -48,14 +48,17 @@ fun getPathsForBlockstate(block: FileDsl<Block>, stateMapper: ((block: Block) ->
 fun getPathForMRL(modelResourceLocation: ModelResourceLocation) =
         getAssetPath(modelResourceLocation.namespace) + +"/blockstates/${modelResourceLocation.path}.json"
 
+fun getPathForModel(type: String, namespace: String, name: String) =
+        getAssetPath(namespace) + +"/models/$type/$name.json"
+
 fun getPathForBlockModel(block: FileDsl<Block>) = getPathForBlockModel(block, block.key.path)
 
 fun getPathForBlockModel(block: FileDsl<Block>, variant: String) =
-        getAssetPath(block.key.namespace) + +"/models/block/$variant.json"
+        getPathForModel("block", block.key.namespace, variant)
 
 fun getPathForItemModel(item: FileDsl<Item>, variantName: String? = null): String {
     val varname = variantName ?: item.key.path
-    return getAssetPath(item.key.namespace) + +"/models/item/$varname.json"
+    return getPathForModel("item", varname.substringBefore(':', item.key.namespace), varname.substringAfter(':'))
 }
 
 fun getAssetPath(modid: String) =
@@ -74,11 +77,11 @@ fun generateBaseItemModel(item: FileDsl<Item>, variantName: String? = null, pare
 
 fun generateRegularItemModel(item: FileDsl<Item>, variantName: String? = null, parent: String = "item/generated"): JsonObject {
     val varname = variantName ?: item.key.path
-    val path = (item.value as? ICustomTexturePath)?.texturePath(varname) ?: "items/$varname"
+    val path = (item.value as? ICustomTexturePath)?.texturePath(varname) ?: "items/${varname.substringAfter(':')}"
     return jsonObject {
         "parent"(parent)
         "textures" {
-            "layer0"("${item.key.namespace}:$path")
+            "layer0"("${varname.substringBefore(':', item.key.namespace)}:$path")
         }
     }
 }


### PR DESCRIPTION
This lets you use custom namespaces for them (to use in combination with the `meshDefinition` overriding).
Behaviour when the variants don't have a namespace is unchanged.